### PR TITLE
CI: Use Rust stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select nightly toolchain
-        run: rustup default nightly
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Install system dependencies

--- a/libwebauthn/src/lib.rs
+++ b/libwebauthn/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(option_get_or_insert_default)]
-
 pub mod fido;
 pub mod ops;
 pub mod pin;


### PR DESCRIPTION
This crate compiles fine with the latest Rust stable (1.69) if you remove `#![feature(option_get_or_insert_default)]` from `libwebauthn/src/lib.rs`. That feature is not used anywhere here and can be removed.