### PR TITLE
Fix #15: Add SetPIN and ChangePIN

### DIFF
--- a/libwebauthn/examples/change_pin_hid.rs
+++ b/libwebauthn/examples/change_pin_hid.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 use tracing_subscriber::{self, EnvFilter};
 
-use libwebauthn::pin::{PinProvider, StdinPromptPinProvider};
+use libwebauthn::pin::{PinManagement, PinProvider, StdinPromptPinProvider};
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::Device;
-use libwebauthn::webauthn::{Error as WebAuthnError, WebAuthn};
+use libwebauthn::webauthn::Error as WebAuthnError;
 use std::io::{self, Write};
 use text_io::read;
 
@@ -44,7 +44,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
         let response = loop {
             match channel
-                .webauthn_change_pin(&pin_provider, new_pin.clone(), TIMEOUT)
+                .change_pin(&pin_provider, new_pin.clone(), TIMEOUT)
                 .await
             {
                 Ok(response) => break Ok(response),

--- a/libwebauthn/examples/change_pin_hid.rs
+++ b/libwebauthn/examples/change_pin_hid.rs
@@ -1,0 +1,66 @@
+use std::error::Error;
+use std::time::Duration;
+
+use tracing_subscriber::{self, EnvFilter};
+
+use libwebauthn::pin::{PinProvider, StdinPromptPinProvider};
+use libwebauthn::transport::hid::list_devices;
+use libwebauthn::transport::Device;
+use libwebauthn::webauthn::{Error as WebAuthnError, WebAuthn};
+use std::io::{self, Write};
+use text_io::read;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+fn setup_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .without_time()
+        .init();
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    setup_logging();
+
+    let devices = list_devices().await.unwrap();
+    println!("Devices found: {:?}", devices);
+    let pin_provider: Box<dyn PinProvider> = Box::new(StdinPromptPinProvider::new());
+
+    for mut device in devices {
+        println!("Selected HID authenticator: {}", &device);
+        device.wink(TIMEOUT).await?;
+
+        let mut channel = device.channel().await?;
+
+        print!("PIN: Please enter the _new_ PIN: ");
+        io::stdout().flush().unwrap();
+        let new_pin: String = read!("{}\n");
+
+        if &new_pin == "" {
+            println!("PIN: No PIN provided, cancelling operation.");
+            return Ok(());
+        }
+
+        let response = loop {
+            match channel
+                .webauthn_change_pin(&pin_provider, new_pin.clone(), TIMEOUT)
+                .await
+            {
+                Ok(response) => break Ok(response),
+                Err(WebAuthnError::Ctap(ctap_error)) => {
+                    if ctap_error.is_retryable_user_error() {
+                        println!("Oops, try again! Error: {}", ctap_error);
+                        continue;
+                    }
+                    break Err(WebAuthnError::Ctap(ctap_error));
+                }
+                Err(err) => break Err(err),
+            };
+        }
+        .unwrap();
+        println!("WebAuthn MakeCredential response: {:?}", response);
+    }
+
+    Ok(())
+}

--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -472,8 +472,7 @@ where
 
             // Device does not support PIN
             None => {
-                // TODO: What's the correct error here? Spec is unclear. Maybe just not early-return and let the device error out for us.
-                return Err(Error::Ctap(CtapError::UnsupportedOption));
+                return Err(Error::Platform(PlatformError::PinNotSupported));
             }
         };
 

--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -22,7 +22,7 @@ use crate::{
         ctap2::{Ctap2, Ctap2ClientPinRequest, Ctap2PinUvAuthProtocol},
         CtapError,
     },
-    transport::Channel,
+    transport::{error::PlatformError, Channel},
     webauthn::{obtain_pin, obtain_shared_secret, select_uv_proto},
 };
 
@@ -455,14 +455,12 @@ where
         // If the minPINLength member of the authenticatorGetInfo response is absent, then let platformMinPINLengthInCodePoints be 4.
         if new_pin.as_bytes().len() < get_info_response.min_pin_length.unwrap_or(4) as usize {
             // If platformCollectedPinLengthInCodePoints is less than platformMinPINLengthInCodePoints then the platform SHOULD display a "PIN too short" error message to the user.
-            // TODO: New error for "PIN too short" vs. "PIN too long"?
-            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+            return Err(Error::Platform(PlatformError::PinTooShort));
         }
 
         // If the byte length of "newPin" is greater than the max UTF-8 representation limit of 63 bytes, then the platform SHOULD display a "PIN too long" error message to the user.
         if new_pin.as_bytes().len() >= 64 {
-            // TODO: New error for "PIN too short" vs. "PIN too long"?
-            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+            return Err(Error::Platform(PlatformError::PinTooLong));
         }
 
         let current_pin = match get_info_response.options.as_ref().unwrap().get("clientPin") {

--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -1,8 +1,11 @@
+use std::time::Duration;
+
 use super::transport::error::Error;
 
 use aes::cipher::{block_padding::NoPadding, BlockDecryptMut};
 use async_trait::async_trait;
 use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+use ctap_types::cose;
 use hkdf::Hkdf;
 use hmac::Mac;
 use p256::{
@@ -13,9 +16,15 @@ use rand::{rngs::OsRng, thread_rng, Rng};
 use sha2::{Digest, Sha256};
 use tracing::{error, info, instrument, warn};
 use x509_parser::nom::AsBytes;
-use ctap_types::cose;
 
-use crate::proto::{ctap2::Ctap2PinUvAuthProtocol, CtapError};
+use crate::{
+    proto::{
+        ctap2::{Ctap2, Ctap2ClientPinRequest, Ctap2PinUvAuthProtocol},
+        CtapError,
+    },
+    transport::Channel,
+    webauthn::{obtain_pin, obtain_shared_secret, select_uv_proto},
+};
 
 type Aes256CbcEncryptor = cbc::Encryptor<aes::Aes256>;
 type Aes256CbcDecryptor = cbc::Decryptor<aes::Aes256>;
@@ -176,8 +185,8 @@ impl ECPrivateKeyPinUvAuthProtocol for PinUvAuthProtocolOne {
 }
 
 impl<P> ECDHPinUvAuthProtocol for P
-    where
-        P: ECPrivateKeyPinUvAuthProtocol,
+where
+    P: ECPrivateKeyPinUvAuthProtocol,
 {
     #[instrument(skip_all)]
     fn encapsulate(
@@ -418,4 +427,105 @@ pub fn hkdf_sha256(salt: &[u8], ikm: &[u8], info: &[u8]) -> Vec<u8> {
     hk.expand(info, &mut okm)
         .expect("32 is a valid length for Sha256 to output");
     Vec::from(okm)
+}
+
+#[async_trait]
+pub trait PinManagement {
+    async fn change_pin(
+        &mut self,
+        pin_provider: &Box<dyn PinProvider>,
+        new_pin: String,
+        timeout: Duration,
+    ) -> Result<(), Error>;
+}
+
+#[async_trait]
+impl<C> PinManagement for C
+where
+    C: Channel,
+{
+    async fn change_pin(
+        &mut self,
+        pin_provider: &Box<dyn PinProvider>,
+        new_pin: String,
+        timeout: Duration,
+    ) -> Result<(), Error> {
+        let get_info_response = self.ctap2_get_info().await?;
+
+        // If the minPINLength member of the authenticatorGetInfo response is absent, then let platformMinPINLengthInCodePoints be 4.
+        if new_pin.as_bytes().len() < get_info_response.min_pin_length.unwrap_or(4) as usize {
+            // If platformCollectedPinLengthInCodePoints is less than platformMinPINLengthInCodePoints then the platform SHOULD display a "PIN too short" error message to the user.
+            // TODO: New error for "PIN too short" vs. "PIN too long"?
+            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+        }
+
+        // If the byte length of "newPin" is greater than the max UTF-8 representation limit of 63 bytes, then the platform SHOULD display a "PIN too long" error message to the user.
+        if new_pin.as_bytes().len() >= 64 {
+            // TODO: New error for "PIN too short" vs. "PIN too long"?
+            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+        }
+
+        let current_pin = match get_info_response.options.as_ref().unwrap().get("clientPin") {
+            // Obtaining the current PIN, if one is set
+            Some(true) => Some(obtain_pin(self, pin_provider, timeout).await?),
+
+            // No PIN set yet
+            Some(false) => None,
+
+            // Device does not support PIN
+            None => {
+                // TODO: What's the correct error here? Spec is unclear. Maybe just not early-return and let the device error out for us.
+                return Err(Error::Ctap(CtapError::UnsupportedOption));
+            }
+        };
+
+        // In preparation for obtaining pinUvAuthToken, the platform:
+        // * Obtains a shared secret.
+        let uv_proto = select_uv_proto(&get_info_response).await?;
+        let (public_key, shared_secret) = obtain_shared_secret(self, &uv_proto, timeout).await?;
+
+        // paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)
+        let mut padded_new_pin = new_pin.as_bytes().to_vec();
+        padded_new_pin.resize(64, 0x00);
+
+        // newPinEnc: the result of calling encrypt(shared secret, paddedPin) where
+        let new_pin_enc = uv_proto.encrypt(&shared_secret, &padded_new_pin)?;
+
+        let req = match current_pin {
+            Some(curr_pin) => {
+                // pinHashEnc: The result of calling encrypt(shared secret, LEFT(SHA-256(curPin), 16)).
+                let pin_hash = pin_hash(&curr_pin);
+                let pin_hash_enc = uv_proto.encrypt(&shared_secret, &pin_hash)?;
+
+                // pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc || pinHashEnc)
+                let uv_auth_param = uv_proto.authenticate(
+                    &shared_secret,
+                    &[new_pin_enc.as_slice(), pin_hash_enc.as_slice()].concat(),
+                );
+
+                Ctap2ClientPinRequest::new_change_pin(
+                    uv_proto.version(),
+                    &new_pin_enc,
+                    &pin_hash_enc,
+                    public_key,
+                    &uv_auth_param,
+                )
+            }
+            None => {
+                // pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc).
+                let uv_auth_param = uv_proto.authenticate(&shared_secret, &new_pin_enc);
+
+                Ctap2ClientPinRequest::new_set_pin(
+                    uv_proto.version(),
+                    &new_pin_enc,
+                    public_key,
+                    &uv_auth_param,
+                )
+            }
+        };
+
+        // On success, this is an all-empty Ctap2ClientPinResponse
+        let _ = self.ctap2_client_pin(&req, timeout).await?;
+        Ok(())
+    }
 }

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -562,7 +562,7 @@ pub struct Ctap2GetInfoResponse {
 
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_pin_length: Option<u32>,
+    pub min_pin_length: Option<u32>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -784,6 +784,47 @@ impl Ctap2ClientPinRequest {
             permissions_rpid: Some(permissions_rpid.to_owned()),
         }
     }
+
+    pub fn new_change_pin(
+        protocol: Ctap2PinUvAuthProtocol,
+        new_pin_enc: &[u8],
+        curr_pin_enc: &[u8],
+        public_key: PublicKey,
+        uv_auth_param: &[u8],
+    ) -> Self {
+        Self {
+            protocol: Some(protocol),
+            command: Ctap2PinUvAuthProtocolCommand::ChangePin,
+            key_agreement: Some(public_key),
+            uv_auth_param: Some(ByteBuf::from(uv_auth_param)),
+            new_pin_encrypted: Some(ByteBuf::from(new_pin_enc)),
+            pin_hash_encrypted: Some(ByteBuf::from(curr_pin_enc)),
+            unused_07: (),
+            unused_08: (),
+            permissions: None,
+            permissions_rpid: None,
+        }
+    }
+
+    pub fn new_set_pin(
+        protocol: Ctap2PinUvAuthProtocol,
+        new_pin_enc: &[u8],
+        public_key: PublicKey,
+        uv_auth_param: &[u8],
+    ) -> Self {
+        Self {
+            protocol: Some(protocol),
+            command: Ctap2PinUvAuthProtocolCommand::SetPin,
+            key_agreement: Some(public_key),
+            uv_auth_param: Some(ByteBuf::from(uv_auth_param)),
+            new_pin_encrypted: Some(ByteBuf::from(new_pin_enc)),
+            pin_hash_encrypted: None,
+            unused_07: (),
+            unused_08: (),
+            permissions: None,
+            permissions_rpid: None,
+        }
+    }
 }
 
 bitflags! {
@@ -817,7 +858,7 @@ pub enum Ctap2PinUvAuthProtocolCommand {
     GetPinUvAuthTokenUsingPinWithPermissions = 0x09,
 }
 
-#[derive(Debug, Clone, DeserializeIndexed)]
+#[derive(Debug, Clone, Default, DeserializeIndexed)]
 #[serde_indexed(offset = 1)]
 pub struct Ctap2ClientPinResponse {
     /// keyAgreement (0x01)

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -148,10 +148,16 @@ where
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
         };
-        let ctap_response: Ctap2ClientPinResponse =
-            from_slice(&cbor_response.data.unwrap()).unwrap();
-        debug!("CTAP2 ClientPin successful");
-        trace!(?ctap_response);
-        Ok(ctap_response)
+        if let Some(data) = cbor_response.data {
+            let ctap_response: Ctap2ClientPinResponse = from_slice(&data).unwrap();
+            debug!("CTAP2 ClientPin successful");
+            trace!(?ctap_response);
+            Ok(ctap_response)
+        } else {
+            // Seems like a bug in serde_indexed: https://github.com/trussed-dev/serde-indexed/issues/10
+            // Can't deserialize an empty vec[], even though everything is optional and marked as default.
+            // So we work around it here by creating our own default value.
+            Ok(Ctap2ClientPinResponse::default())
+        }
     }
 }

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -1,6 +1,20 @@
 pub use crate::proto::CtapError;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+pub enum PlatformError {
+    PinTooShort,
+    PinTooLong,
+}
+
+impl std::error::Error for PlatformError {}
+
+impl std::fmt::Display for PlatformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TransportError {
     ConnectionFailed,
     ConnectionLost,
@@ -23,6 +37,7 @@ impl std::fmt::Display for TransportError {
 pub enum Error {
     Transport(TransportError),
     Ctap(CtapError),
+    Platform(PlatformError),
 }
 
 impl std::error::Error for Error {}
@@ -42,5 +57,11 @@ impl From<CtapError> for Error {
 impl From<TransportError> for Error {
     fn from(error: TransportError) -> Self {
         Error::Transport(error)
+    }
+}
+
+impl From<PlatformError> for Error {
+    fn from(error: PlatformError) -> Self {
+        Error::Platform(error)
     }
 }

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -4,6 +4,7 @@ pub use crate::proto::CtapError;
 pub enum PlatformError {
     PinTooShort,
     PinTooLong,
+    PinNotSupported,
 }
 
 impl std::error::Error for PlatformError {}

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -19,8 +19,8 @@ use crate::proto::ctap2::{
     Ctap2, Ctap2ClientPinRequest, Ctap2GetAssertionRequest, Ctap2GetInfoResponse,
     Ctap2MakeCredentialRequest, Ctap2UserVerifiableRequest, Ctap2UserVerificationOperation,
 };
-use crate::transport::Channel;
 pub use crate::transport::error::{CtapError, Error, TransportError};
+use crate::transport::Channel;
 
 #[async_trait]
 pub trait WebAuthn {
@@ -53,6 +53,12 @@ pub trait WebAuthn {
         &mut self,
         op: &GetAssertionRequest,
     ) -> Result<GetAssertionResponse, Error>;
+    async fn webauthn_change_pin(
+        &mut self,
+        pin_provider: &Box<dyn PinProvider>,
+        new_pin: String,
+        timeout: Duration,
+    ) -> Result<(), Error>;
 
     async fn _negotiate_protocol(&mut self, allow_u2f: bool) -> Result<FidoProtocol, Error>;
 }
@@ -74,8 +80,8 @@ async fn select_uv_proto(
 
 #[async_trait]
 impl<C> WebAuthn for C
-    where
-        C: Channel,
+where
+    C: Channel,
 {
     #[instrument(skip_all, fields(dev = % self))]
     async fn webauthn_make_credential(
@@ -104,7 +110,7 @@ impl<C> WebAuthn for C
             pin_provider,
             op.timeout,
         )
-            .await?;
+        .await?;
         self.ctap2_make_credential(&ctap2_request, op.timeout).await
     }
 
@@ -145,7 +151,7 @@ impl<C> WebAuthn for C
             pin_provider,
             op.timeout,
         )
-            .await?;
+        .await?;
 
         let response = self.ctap2_get_assertion(&ctap2_request, op.timeout).await?;
         let count = response.credentials_count.unwrap_or(1);
@@ -211,6 +217,91 @@ impl<C> WebAuthn for C
         }
         Ok(fido_protocol)
     }
+
+    async fn webauthn_change_pin(
+        &mut self,
+        pin_provider: &Box<dyn PinProvider>,
+        new_pin: String,
+        timeout: Duration,
+    ) -> Result<(), Error> {
+        let get_info_response = self.ctap2_get_info().await?;
+
+        // If the minPINLength member of the authenticatorGetInfo response is absent, then let platformMinPINLengthInCodePoints be 4.
+        if new_pin.as_bytes().len() < get_info_response.min_pin_length.unwrap_or(4) as usize {
+            // If platformCollectedPinLengthInCodePoints is less than platformMinPINLengthInCodePoints then the platform SHOULD display a "PIN too short" error message to the user.
+            // TODO: New error for "PIN too short" vs. "PIN too long"?
+            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+        }
+
+        // If the byte length of "newPin" is greater than the max UTF-8 representation limit of 63 bytes, then the platform SHOULD display a "PIN too long" error message to the user.
+        if new_pin.as_bytes().len() >= 64 {
+            // TODO: New error for "PIN too short" vs. "PIN too long"?
+            return Err(Error::Ctap(CtapError::PINPolicyViolation));
+        }
+
+        let current_pin = match get_info_response.options.as_ref().unwrap().get("clientPin") {
+            // Obtaining the current PIN, if one is set
+            Some(true) => Some(obtain_pin(self, pin_provider, timeout).await?),
+
+            // No PIN set yet
+            Some(false) => None,
+
+            // Device does not support PIN
+            None => {
+                // TODO: What's the correct error here? Spec is unclear. Maybe just not early-return and let the device error out for us.
+                return Err(Error::Ctap(CtapError::UnsupportedOption));
+            }
+        };
+
+        // In preparation for obtaining pinUvAuthToken, the platform:
+        // * Obtains a shared secret.
+        let uv_proto = select_uv_proto(&get_info_response).await?;
+        let (public_key, shared_secret) = obtain_shared_secret(self, &uv_proto, timeout).await?;
+
+        // paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)
+        let mut padded_new_pin = new_pin.as_bytes().to_vec();
+        padded_new_pin.resize(64, 0x00);
+
+        // newPinEnc: the result of calling encrypt(shared secret, paddedPin) where
+        let new_pin_enc = uv_proto.encrypt(&shared_secret, &padded_new_pin)?;
+
+        let req = match current_pin {
+            Some(curr_pin) => {
+                // pinHashEnc: The result of calling encrypt(shared secret, LEFT(SHA-256(curPin), 16)).
+                let pin_hash = pin_hash(&curr_pin);
+                let pin_hash_enc = uv_proto.encrypt(&shared_secret, &pin_hash)?;
+
+                // pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc || pinHashEnc)
+                let uv_auth_param = uv_proto.authenticate(
+                    &shared_secret,
+                    &[new_pin_enc.as_slice(), pin_hash_enc.as_slice()].concat(),
+                );
+
+                Ctap2ClientPinRequest::new_change_pin(
+                    uv_proto.version(),
+                    &new_pin_enc,
+                    &pin_hash_enc,
+                    public_key,
+                    &uv_auth_param,
+                )
+            }
+            None => {
+                // pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc).
+                let uv_auth_param = uv_proto.authenticate(&shared_secret, &new_pin_enc);
+
+                Ctap2ClientPinRequest::new_set_pin(
+                    uv_proto.version(),
+                    &new_pin_enc,
+                    public_key,
+                    &uv_auth_param,
+                )
+            }
+        };
+
+        // On success, this is an all-empty Ctap2ClientPinResponse
+        let _ = self.ctap2_client_pin(&req, timeout).await?;
+        Ok(())
+    }
 }
 
 #[instrument(skip_all)]
@@ -221,9 +312,9 @@ async fn user_verification<R, C>(
     pin_provider: &Box<dyn PinProvider>,
     timeout: Duration,
 ) -> Result<(), Error>
-    where
-        C: Channel,
-        R: Ctap2UserVerifiableRequest,
+where
+    C: Channel,
+    R: Ctap2UserVerifiableRequest,
 {
     let get_info_response = channel.ctap2_get_info().await?;
 
@@ -325,8 +416,8 @@ async fn obtain_shared_secret<C>(
     pin_proto: &Box<dyn PinUvAuthProtocol>,
     timeout: Duration,
 ) -> Result<(PublicKey, Vec<u8>), Error>
-    where
-        C: Channel,
+where
+    C: Channel,
 {
     let client_pin_request = Ctap2ClientPinRequest::new_get_key_agreement(pin_proto.version());
     let client_pin_response = channel
@@ -344,8 +435,8 @@ async fn obtain_pin<C>(
     pin_provider: &Box<dyn PinProvider>,
     timeout: Duration,
 ) -> Result<Vec<u8>, Error>
-    where
-        C: Channel,
+where
+    C: Channel,
 {
     let attempts_left = channel
         .ctap2_client_pin(&Ctap2ClientPinRequest::new_get_pin_retries(), timeout)


### PR DESCRIPTION
To get a feel for the project, I figured, implementing something smaller might be a good start.

I have 3 TODOs in there: 2 are related to PinTooShort/PinTooLong errors. The platform "should" display this to the user. I currently only return a PinPolicyViolation in both cases, as otherwise I'd need to have platform-specific error-codes that are not specified in the spec. Should be simple enough, if you want me to do it. Otherwise we ignore the "should" and only tell the user something is wrong with the PIN-length.

The third TODO is what to do if the device doesn't even support Pins. Maybe I have overlooked it, but the spec doesn't seem to mention what exact error should be returned in that case. We can abort early, as I'm doing right now, or simply forward a SetPIN-request to the device at let it error out for us.