### PR TITLE
Add possibility to cache pinUvAuthToken in PinProvider

### DIFF
--- a/libwebauthn/src/management.rs
+++ b/libwebauthn/src/management.rs
@@ -11,7 +11,7 @@ use crate::webauthn::{user_verification, UsedPinUvAuthToken};
 use crate::{
     ops::webauthn::UserVerificationRequirement,
     proto::ctap2::{
-        ClientPinRequestPermissions, Ctap2, Ctap2AuthenticatorConfigRequest,
+        Ctap2, Ctap2AuthTokenPermissionRole, Ctap2AuthenticatorConfigRequest,
         Ctap2UserVerifiableRequest,
     },
 };
@@ -214,8 +214,8 @@ impl Ctap2UserVerifiableRequest for Ctap2AuthenticatorConfigRequest {
         unreachable!()
     }
 
-    fn permissions(&self) -> ClientPinRequestPermissions {
-        return ClientPinRequestPermissions::AUTHENTICATOR_CONFIGURATION;
+    fn permissions(&self) -> Ctap2AuthTokenPermissionRole {
+        return Ctap2AuthTokenPermissionRole::AUTHENTICATOR_CONFIGURATION;
     }
 
     fn permissions_rpid(&self) -> Option<&str> {

--- a/libwebauthn/src/management.rs
+++ b/libwebauthn/src/management.rs
@@ -1,11 +1,13 @@
 use serde_cbor::ser::to_vec;
 use std::time::Duration;
+use tracing::info;
 
 use crate::pin::{PinProvider, PinUvAuthProtocol};
 use crate::proto::ctap2::Ctap2AuthenticatorConfigCommand;
 pub use crate::transport::error::{CtapError, Error, TransportError};
 use crate::transport::Channel;
-use crate::webauthn::user_verification;
+use crate::webauthn::handle_errors;
+use crate::webauthn::{user_verification, UsedPinUvAuthToken};
 use crate::{
     ops::webauthn::UserVerificationRequirement,
     proto::ctap2::{
@@ -64,17 +66,22 @@ where
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_toggle_always_uv();
 
-        user_verification(
-            self,
-            UserVerificationRequirement::Required,
-            &mut req,
-            pin_provider,
-            timeout,
-        )
-        .await?;
-
-        // On success, this is an all-empty Ctap2ClientPinResponse
-        self.ctap2_authenticator_config(&req, timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                UserVerificationRequirement::Required,
+                &mut req,
+                pin_provider,
+                timeout,
+            )
+            .await?;
+            // On success, this is an all-empty Ctap2AuthenticatorConfigResponse
+            handle_errors!(
+                self,
+                self.ctap2_authenticator_config(&req, timeout).await,
+                uv_auth_used
+            )
+        }
     }
 
     async fn enable_enterprise_attestation(
@@ -84,17 +91,22 @@ where
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_enable_enterprise_attestation();
 
-        user_verification(
-            self,
-            UserVerificationRequirement::Required,
-            &mut req,
-            pin_provider,
-            timeout,
-        )
-        .await?;
-
-        // On success, this is an all-empty Ctap2ClientPinResponse
-        self.ctap2_authenticator_config(&req, timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                UserVerificationRequirement::Required,
+                &mut req,
+                pin_provider,
+                timeout,
+            )
+            .await?;
+            // On success, this is an all-empty Ctap2AuthenticatorConfigResponse
+            handle_errors!(
+                self,
+                self.ctap2_authenticator_config(&req, timeout).await,
+                uv_auth_used
+            )
+        }
     }
 
     async fn set_min_pin_length(
@@ -105,17 +117,22 @@ where
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length(new_pin_length);
 
-        user_verification(
-            self,
-            UserVerificationRequirement::Required,
-            &mut req,
-            pin_provider,
-            timeout,
-        )
-        .await?;
-
-        // On success, this is an all-empty Ctap2ClientPinResponse
-        self.ctap2_authenticator_config(&req, timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                UserVerificationRequirement::Required,
+                &mut req,
+                pin_provider,
+                timeout,
+            )
+            .await?;
+            // On success, this is an all-empty Ctap2AuthenticatorConfigResponse
+            handle_errors!(
+                self,
+                self.ctap2_authenticator_config(&req, timeout).await,
+                uv_auth_used
+            )
+        }
     }
 
     async fn force_change_pin(
@@ -126,17 +143,22 @@ where
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_force_change_pin(force);
 
-        user_verification(
-            self,
-            UserVerificationRequirement::Required,
-            &mut req,
-            pin_provider,
-            timeout,
-        )
-        .await?;
-
-        // On success, this is an all-empty Ctap2ClientPinResponse
-        self.ctap2_authenticator_config(&req, timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                UserVerificationRequirement::Required,
+                &mut req,
+                pin_provider,
+                timeout,
+            )
+            .await?;
+            // On success, this is an all-empty Ctap2AuthenticatorConfigResponse
+            handle_errors!(
+                self,
+                self.ctap2_authenticator_config(&req, timeout).await,
+                uv_auth_used
+            )
+        }
     }
 
     async fn set_min_pin_length_rpids(
@@ -146,18 +168,22 @@ where
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length_rpids(rpids);
-
-        user_verification(
-            self,
-            UserVerificationRequirement::Required,
-            &mut req,
-            pin_provider,
-            timeout,
-        )
-        .await?;
-
-        // On success, this is an all-empty Ctap2ClientPinResponse
-        self.ctap2_authenticator_config(&req, timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                UserVerificationRequirement::Required,
+                &mut req,
+                pin_provider,
+                timeout,
+            )
+            .await?;
+            // On success, this is an all-empty Ctap2AuthenticatorConfigResponse
+            handle_errors!(
+                self,
+                self.ctap2_authenticator_config(&req, timeout).await,
+                uv_auth_used
+            )
+        }
     }
 }
 

--- a/libwebauthn/src/proto/ctap2/mod.rs
+++ b/libwebauthn/src/proto/ctap2/mod.rs
@@ -7,7 +7,7 @@ mod protocol;
 
 pub use model::Ctap2GetInfoResponse;
 pub use model::{
-    ClientPinRequestPermissions, Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier,
+    Ctap2AuthTokenPermissionRole, Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier,
     Ctap2ClientPinRequest, Ctap2CommandCode, Ctap2CredentialType, Ctap2MakeCredentialOptions,
     Ctap2PinUvAuthProtocol, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
     Ctap2PublicKeyCredentialType, Ctap2PublicKeyCredentialUserEntity, Ctap2Transport,

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -881,6 +881,7 @@ impl Ctap2ClientPinRequest {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ClientPinRequestPermissions: u32 {
         const MAKE_CREDENTIAL = 0x01;
         const GET_ASSERTION = 0x02;
@@ -892,7 +893,7 @@ bitflags! {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
 pub enum Ctap2PinUvAuthProtocol {
     One = 1,
     Two = 2,

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -478,7 +478,7 @@ pub trait Ctap2UserVerifiableRequest {
         uv_auth_token: &[u8],
     );
     fn client_data_hash(&self) -> &[u8];
-    fn permissions(&self) -> ClientPinRequestPermissions;
+    fn permissions(&self) -> Ctap2AuthTokenPermissionRole;
     fn permissions_rpid(&self) -> Option<&str>;
 }
 
@@ -506,10 +506,10 @@ impl Ctap2UserVerifiableRequest for Ctap2MakeCredentialRequest {
         self.hash.as_slice()
     }
 
-    fn permissions(&self) -> ClientPinRequestPermissions {
+    fn permissions(&self) -> Ctap2AuthTokenPermissionRole {
         // GET_ASSERTION needed for pre-flight requests
-        return ClientPinRequestPermissions::MAKE_CREDENTIAL
-            | ClientPinRequestPermissions::GET_ASSERTION;
+        return Ctap2AuthTokenPermissionRole::MAKE_CREDENTIAL
+            | Ctap2AuthTokenPermissionRole::GET_ASSERTION;
     }
 
     fn permissions_rpid(&self) -> Option<&str> {
@@ -539,8 +539,8 @@ impl Ctap2UserVerifiableRequest for Ctap2GetAssertionRequest {
         self.client_data_hash.as_slice()
     }
 
-    fn permissions(&self) -> ClientPinRequestPermissions {
-        return ClientPinRequestPermissions::GET_ASSERTION;
+    fn permissions(&self) -> Ctap2AuthTokenPermissionRole {
+        return Ctap2AuthTokenPermissionRole::GET_ASSERTION;
     }
 
     fn permissions_rpid(&self) -> Option<&str> {
@@ -801,7 +801,7 @@ impl Ctap2ClientPinRequest {
         protocol: Ctap2PinUvAuthProtocol,
         public_key: PublicKey,
         pin_hash_enc: &[u8],
-        permissions: ClientPinRequestPermissions,
+        permissions: Ctap2AuthTokenPermissionRole,
         permissions_rpid: Option<&str>,
     ) -> Self {
         Self {
@@ -821,7 +821,7 @@ impl Ctap2ClientPinRequest {
     pub fn new_get_uv_token_with_perm(
         protocol: Ctap2PinUvAuthProtocol,
         public_key: PublicKey,
-        permissions: ClientPinRequestPermissions,
+        permissions: Ctap2AuthTokenPermissionRole,
         permissions_rpid: Option<&str>,
     ) -> Self {
         Self {
@@ -882,7 +882,7 @@ impl Ctap2ClientPinRequest {
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct ClientPinRequestPermissions: u32 {
+    pub struct Ctap2AuthTokenPermissionRole: u32 {
         const MAKE_CREDENTIAL = 0x01;
         const GET_ASSERTION = 0x02;
         const CREDENTIAL_MANAGEMENT = 0x04;

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -97,6 +97,10 @@ where
         trace!(?request);
         self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
         let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        match cbor_response.status_code {
+            CtapError::Ok => (),
+            error => return Err(Error::Ctap(error)),
+        };
         let ctap_response: Ctap2GetAssertionResponse =
             from_slice(&cbor_response.data.unwrap()).unwrap();
         debug!("CTAP2 GetAssertion successful");

--- a/libwebauthn/src/transport/ble/channel.rs
+++ b/libwebauthn/src/transport/ble/channel.rs
@@ -8,7 +8,7 @@ use crate::proto::ctap2::cbor::{CborRequest, CborResponse};
 use crate::proto::CtapError;
 use crate::transport::ble::bluez;
 use crate::transport::channel::{
-    Channel, ChannelStatus, Ctap2AuthTokenIdentifier, Ctap2AuthTokenStore,
+    Channel, ChannelStatus, Ctap2AuthTokenPermission, Ctap2AuthTokenStore,
 };
 use crate::transport::device::SupportedProtocols;
 use crate::transport::error::{Error, TransportError};
@@ -27,7 +27,7 @@ pub struct BleChannel<'a> {
     device: &'a BleDevice,
     connection: Connection,
     revision: FidoRevision,
-    auth_token_storage: Option<(Ctap2AuthTokenIdentifier, Vec<u8>)>,
+    auth_token: Option<(Ctap2AuthTokenPermission, Vec<u8>)>,
 }
 
 impl<'a> BleChannel<'a> {
@@ -46,7 +46,7 @@ impl<'a> BleChannel<'a> {
             device,
             connection,
             revision,
-            auth_token_storage: None,
+            auth_token: None,
         };
         bluez::notify_start(&channel.connection)
             .await
@@ -161,22 +161,22 @@ impl<'a> Channel for BleChannel<'a> {
 impl Ctap2AuthTokenStore for BleChannel<'_> {
     fn store_uv_auth_token(
         &mut self,
-        identifier: Ctap2AuthTokenIdentifier,
+        permission: Ctap2AuthTokenPermission,
         pin_uv_auth_token: &[u8],
     ) {
-        self.auth_token_storage = Some((identifier, pin_uv_auth_token.to_vec()));
+        self.auth_token = Some((permission, pin_uv_auth_token.to_vec()));
     }
 
-    fn get_uv_auth_token(&self, identifier: &Ctap2AuthTokenIdentifier) -> Option<&[u8]> {
-        if let Some((id, token)) = &self.auth_token_storage {
-            if id.is_satisfied_by(identifier) {
-                return Some(token);
+    fn get_uv_auth_token(&self, requested_permission: &Ctap2AuthTokenPermission) -> Option<&[u8]> {
+        if let Some((stored_permission, stored_token)) = &self.auth_token {
+            if stored_permission.contains(requested_permission) {
+                return Some(stored_token);
             }
         }
         None
     }
 
     fn clear_uv_auth_token_store(&mut self) {
-        self.auth_token_storage = None;
+        self.auth_token = None;
     }
 }

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -11,7 +11,10 @@ use crate::proto::{
     ctap2::cbor::{CborRequest, CborResponse},
 };
 use crate::transport::error::{Error, TransportError};
-use crate::transport::{channel::ChannelStatus, device::SupportedProtocols, Channel};
+use crate::transport::{
+    channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenIdentifier,
+    Ctap2AuthTokenStore,
+};
 
 use super::known_devices::CableKnownDevice;
 use super::qr_code_device::CableQrCodeDevice;
@@ -84,4 +87,19 @@ impl<'d> Channel for CableChannel<'d> {
             .await
             .ok_or(Error::Transport(TransportError::TransportUnavailable))
     }
+}
+
+impl<'d> Ctap2AuthTokenStore for CableChannel<'d> {
+    fn store_uv_auth_token(
+        &mut self,
+        _identifier: Ctap2AuthTokenIdentifier,
+        _pin_uv_auth_token: &[u8],
+    ) {
+    }
+
+    fn get_uv_auth_token(&self, _identifier: &Ctap2AuthTokenIdentifier) -> Option<&[u8]> {
+        None
+    }
+
+    fn clear_uv_auth_token_store(&mut self) {}
 }

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -12,7 +12,7 @@ use crate::proto::{
 };
 use crate::transport::error::{Error, TransportError};
 use crate::transport::{
-    channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenIdentifier,
+    channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenPermission,
     Ctap2AuthTokenStore,
 };
 
@@ -92,12 +92,12 @@ impl<'d> Channel for CableChannel<'d> {
 impl<'d> Ctap2AuthTokenStore for CableChannel<'d> {
     fn store_uv_auth_token(
         &mut self,
-        _identifier: Ctap2AuthTokenIdentifier,
+        _permission: Ctap2AuthTokenPermission,
         _pin_uv_auth_token: &[u8],
     ) {
     }
 
-    fn get_uv_auth_token(&self, _identifier: &Ctap2AuthTokenIdentifier) -> Option<&[u8]> {
+    fn get_uv_auth_token(&self, _requested_permission: &Ctap2AuthTokenPermission) -> Option<&[u8]> {
         None
     }
 

--- a/libwebauthn/src/transport/channel.rs
+++ b/libwebauthn/src/transport/channel.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Display};
 use std::time::Duration;
 
+use crate::proto::ctap2::{ClientPinRequestPermissions, Ctap2PinUvAuthProtocol};
 use crate::proto::{
     ctap1::apdu::{ApduRequest, ApduResponse},
     ctap2::cbor::{CborRequest, CborResponse},
@@ -19,7 +20,7 @@ pub enum ChannelStatus {
 }
 
 #[async_trait]
-pub trait Channel: Send + Sync + Display {
+pub trait Channel: Send + Sync + Display + Ctap2AuthTokenStore {
     async fn supported_protocols(&self) -> Result<SupportedProtocols, Error>;
     async fn status(&self) -> ChannelStatus;
     async fn close(&mut self);
@@ -29,4 +30,46 @@ pub trait Channel: Send + Sync + Display {
 
     async fn cbor_send(&mut self, request: &CborRequest, timeout: Duration) -> Result<(), Error>;
     async fn cbor_recv(&mut self, timeout: Duration) -> Result<CborResponse, Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ctap2AuthTokenIdentifier {
+    pin_uv_auth_protocol: Ctap2PinUvAuthProtocol,
+    permissions: ClientPinRequestPermissions,
+    permissions_rpid: Option<String>,
+}
+
+impl Ctap2AuthTokenIdentifier {
+    pub fn new(
+        pin_uv_auth_protocol: Ctap2PinUvAuthProtocol,
+        permissions: ClientPinRequestPermissions,
+        permissions_rpid: Option<&str>,
+    ) -> Self {
+        Self {
+            pin_uv_auth_protocol,
+            permissions,
+            permissions_rpid: permissions_rpid.map(str::to_string),
+        }
+    }
+
+    pub fn is_satisfied_by(&self, other: &Ctap2AuthTokenIdentifier) -> bool {
+        if self.pin_uv_auth_protocol != other.pin_uv_auth_protocol {
+            return false;
+        }
+        if self.permissions_rpid != other.permissions_rpid {
+            return false;
+        }
+        self.permissions.contains(other.permissions)
+    }
+}
+
+#[async_trait]
+pub trait Ctap2AuthTokenStore {
+    fn store_uv_auth_token(
+        &mut self,
+        identifier: Ctap2AuthTokenIdentifier,
+        pin_uv_auth_token: &[u8],
+    );
+    fn get_uv_auth_token(&self, identifier: &Ctap2AuthTokenIdentifier) -> Option<&[u8]>;
+    fn clear_uv_auth_token_store(&mut self);
 }

--- a/libwebauthn/src/transport/hid/channel.rs
+++ b/libwebauthn/src/transport/hid/channel.rs
@@ -17,7 +17,9 @@ use tokio::net::UdpSocket;
 
 use crate::proto::ctap1::apdu::{ApduRequest, ApduResponse};
 use crate::proto::ctap2::cbor::{CborRequest, CborResponse};
-use crate::transport::channel::{Channel, ChannelStatus};
+use crate::transport::channel::{
+    Channel, ChannelStatus, Ctap2AuthTokenIdentifier, Ctap2AuthTokenStore,
+};
 use crate::transport::device::SupportedProtocols;
 use crate::transport::error::{Error, TransportError};
 use crate::transport::hid::framing::{
@@ -50,6 +52,7 @@ pub struct HidChannel<'d> {
     device: &'d HidDevice,
     open_device: OpenHidDevice,
     init: InitResponse,
+    auth_token_storage: Option<(Ctap2AuthTokenIdentifier, Vec<u8>)>,
 }
 
 impl<'d> HidChannel<'d> {
@@ -66,6 +69,7 @@ impl<'d> HidChannel<'d> {
                 HidBackendDevice::VirtualDevice(_) => OpenHidDevice::VirtualDevice,
             },
             init: InitResponse::default(),
+            auth_token_storage: None,
         };
         channel.init = channel.init(INIT_TIMEOUT).await?;
         Ok(channel)
@@ -441,5 +445,28 @@ bitflags! {
         const WINK = 0x01;
         const CBOR = 0x04;
         const NO_MSG = 0x08;
+    }
+}
+
+impl Ctap2AuthTokenStore for HidChannel<'_> {
+    fn store_uv_auth_token(
+        &mut self,
+        identifier: Ctap2AuthTokenIdentifier,
+        pin_uv_auth_token: &[u8],
+    ) {
+        self.auth_token_storage = Some((identifier, pin_uv_auth_token.to_vec()));
+    }
+
+    fn get_uv_auth_token(&self, identifier: &Ctap2AuthTokenIdentifier) -> Option<&[u8]> {
+        if let Some((id, token)) = &self.auth_token_storage {
+            if id.is_satisfied_by(identifier) {
+                return Some(token);
+            }
+        }
+        None
+    }
+
+    fn clear_uv_auth_token_store(&mut self) {
+        self.auth_token_storage = None;
     }
 }

--- a/libwebauthn/src/transport/mod.rs
+++ b/libwebauthn/src/transport/mod.rs
@@ -8,7 +8,7 @@ pub mod hid;
 mod channel;
 mod transport;
 
-pub(crate) use channel::Ctap2AuthTokenIdentifier;
+pub(crate) use channel::Ctap2AuthTokenPermission;
 pub use channel::{Channel, Ctap2AuthTokenStore};
 pub use device::Device;
 pub use transport::Transport;

--- a/libwebauthn/src/transport/mod.rs
+++ b/libwebauthn/src/transport/mod.rs
@@ -8,6 +8,7 @@ pub mod hid;
 mod channel;
 mod transport;
 
-pub use channel::Channel;
+pub(crate) use channel::Ctap2AuthTokenIdentifier;
+pub use channel::{Channel, Ctap2AuthTokenStore};
 pub use device::Device;
 pub use transport::Transport;

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -20,7 +20,25 @@ use crate::proto::ctap2::{
     Ctap2MakeCredentialRequest, Ctap2UserVerifiableRequest, Ctap2UserVerificationOperation,
 };
 pub use crate::transport::error::{CtapError, Error, PlatformError, TransportError};
-use crate::transport::Channel;
+use crate::transport::{Channel, Ctap2AuthTokenIdentifier};
+
+macro_rules! handle_errors {
+    ($channel: expr, $resp: expr, $uv_auth_used: expr) => {
+        match $resp {
+            Err(Error::Ctap(CtapError::PINAuthInvalid))
+                if $uv_auth_used == UsedPinUvAuthToken::FromStorage =>
+            {
+                info!("PINAuthInvalid: Clearing auth token storage and trying again.");
+                $channel.clear_uv_auth_token_store();
+                continue;
+            }
+            x => {
+                break x;
+            }
+        }
+    };
+}
+pub(crate) use handle_errors;
 
 #[async_trait]
 pub trait WebAuthn {
@@ -96,15 +114,21 @@ where
         pin_provider: &Box<dyn PinProvider>,
     ) -> Result<MakeCredentialResponse, Error> {
         let mut ctap2_request: Ctap2MakeCredentialRequest = op.into();
-        user_verification(
-            self,
-            op.user_verification,
-            &mut ctap2_request,
-            pin_provider,
-            op.timeout,
-        )
-        .await?;
-        self.ctap2_make_credential(&ctap2_request, op.timeout).await
+        loop {
+            let uv_auth_used = user_verification(
+                self,
+                op.user_verification,
+                &mut ctap2_request,
+                pin_provider,
+                op.timeout,
+            )
+            .await?;
+            handle_errors!(
+                self,
+                self.ctap2_make_credential(&ctap2_request, op.timeout).await,
+                uv_auth_used
+            )
+        }
     }
 
     async fn _webauthn_make_credential_u2f(
@@ -137,20 +161,26 @@ where
         pin_provider: &Box<dyn PinProvider>,
     ) -> Result<GetAssertionResponse, Error> {
         let mut ctap2_request: Ctap2GetAssertionRequest = op.into();
-        user_verification(
-            self,
-            op.user_verification,
-            &mut ctap2_request,
-            pin_provider,
-            op.timeout,
-        )
-        .await?;
-
-        let response = self.ctap2_get_assertion(&ctap2_request, op.timeout).await?;
+        let response = loop {
+            let uv_auth_used = user_verification(
+                self,
+                op.user_verification,
+                &mut ctap2_request,
+                pin_provider,
+                op.timeout,
+            )
+            .await?;
+            handle_errors!(
+                self,
+                self.ctap2_get_assertion(&ctap2_request, op.timeout).await,
+                uv_auth_used
+            )
+        }?;
         let count = response.credentials_count.unwrap_or(1);
         let mut assertions = vec![response];
         for i in 1..count {
             debug!({ i }, "Fetching additional credential");
+            // GetNextAssertion doesn't use PinUVAuthToken, so we don't need to check uv_auth_used here
             assertions.push(self.ctap2_get_next_assertion(op.timeout).await?);
         }
         Ok(assertions.as_slice().into())
@@ -212,6 +242,14 @@ where
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum UsedPinUvAuthToken {
+    FromStorage,
+    NewlyCalculated,
+    LegacyUV,
+    None,
+}
+
 #[instrument(skip_all)]
 pub(crate) async fn user_verification<R, C>(
     channel: &mut C,
@@ -219,7 +257,41 @@ pub(crate) async fn user_verification<R, C>(
     ctap2_request: &mut R,
     pin_provider: &Box<dyn PinProvider>,
     timeout: Duration,
-) -> Result<(), Error>
+) -> Result<UsedPinUvAuthToken, Error>
+where
+    C: Channel,
+    R: Ctap2UserVerifiableRequest,
+{
+    let get_info_response = channel.ctap2_get_info().await?;
+    let uv_proto = select_uv_proto(&get_info_response).await?;
+    let token_identifier = Ctap2AuthTokenIdentifier::new(
+        uv_proto.version(),
+        ctap2_request.permissions(),
+        ctap2_request.permissions_rpid(),
+    );
+    if let Some(uv_auth_token) = channel.get_uv_auth_token(&token_identifier) {
+        ctap2_request.calculate_and_set_uv_auth(&uv_proto, uv_auth_token);
+        Ok(UsedPinUvAuthToken::FromStorage)
+    } else {
+        user_verification_helper(
+            channel,
+            user_verification,
+            ctap2_request,
+            pin_provider,
+            timeout,
+        )
+        .await
+    }
+}
+
+#[instrument(skip_all)]
+async fn user_verification_helper<R, C>(
+    channel: &mut C,
+    user_verification: UserVerificationRequirement,
+    ctap2_request: &mut R,
+    pin_provider: &Box<dyn PinProvider>,
+    timeout: Duration,
+) -> Result<UsedPinUvAuthToken, Error>
 where
     C: Channel,
     R: Ctap2UserVerifiableRequest,
@@ -233,7 +305,7 @@ where
 
     if !uv {
         debug!("User verification not requested by either RP nor authenticator. Ignoring.");
-        return Ok(());
+        return Ok(UsedPinUvAuthToken::None);
     }
 
     if !dev_uv_protected && user_verification.is_required() {
@@ -245,7 +317,7 @@ where
 
     if !dev_uv_protected && user_verification.is_preferred() {
         warn!("User verification is preferred, but not device user verification is not available. Ignoring.");
-        return Ok(());
+        return Ok(UsedPinUvAuthToken::None);
     }
 
     let mut uv_blocked = false;
@@ -260,7 +332,7 @@ where
         if let Ctap2UserVerificationOperation::None = uv_operation {
             debug!("No client operation. Setting deprecated request options.uv flag to true.");
             ctap2_request.ensure_uv_set();
-            return Ok(());
+            return Ok(UsedPinUvAuthToken::LegacyUV);
         }
 
         // For operations that include a PIN, we want to fetch one before obtaining a shared secret.
@@ -334,12 +406,19 @@ where
 
     let uv_auth_token = uv_proto.decrypt(&shared_secret, &encrypted_pin_uv_auth_token)?;
 
+    let token_identifier = Ctap2AuthTokenIdentifier::new(
+        uv_proto.version(),
+        ctap2_request.permissions(),
+        ctap2_request.permissions_rpid(),
+    );
+    channel.store_uv_auth_token(token_identifier, &uv_auth_token);
+
     // If successful, the platform creates the pinUvAuthParam parameter by calling
     // authenticate(pinUvAuthToken, clientDataHash), and goes to Step 1.1.1.
     // Sets the pinUvAuthProtocol parameter to the value as selected when it obtained the shared secret.
     ctap2_request.calculate_and_set_uv_auth(&uv_proto, uv_auth_token.as_slice());
 
-    Ok(())
+    Ok(UsedPinUvAuthToken::NewlyCalculated)
 }
 
 pub(crate) async fn obtain_shared_secret<C>(

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -20,7 +20,7 @@ use crate::proto::ctap2::{
     Ctap2MakeCredentialRequest, Ctap2UserVerifiableRequest, Ctap2UserVerificationOperation,
 };
 pub use crate::transport::error::{CtapError, Error, PlatformError, TransportError};
-use crate::transport::{Channel, Ctap2AuthTokenIdentifier};
+use crate::transport::{Channel, Ctap2AuthTokenPermission};
 
 macro_rules! handle_errors {
     ($channel: expr, $resp: expr, $uv_auth_used: expr) => {
@@ -264,7 +264,7 @@ where
 {
     let get_info_response = channel.ctap2_get_info().await?;
     let uv_proto = select_uv_proto(&get_info_response).await?;
-    let token_identifier = Ctap2AuthTokenIdentifier::new(
+    let token_identifier = Ctap2AuthTokenPermission::new(
         uv_proto.version(),
         ctap2_request.permissions(),
         ctap2_request.permissions_rpid(),
@@ -406,7 +406,7 @@ where
 
     let uv_auth_token = uv_proto.decrypt(&shared_secret, &encrypted_pin_uv_auth_token)?;
 
-    let token_identifier = Ctap2AuthTokenIdentifier::new(
+    let token_identifier = Ctap2AuthTokenPermission::new(
         uv_proto.version(),
         ctap2_request.permissions(),
         ctap2_request.permissions_rpid(),


### PR DESCRIPTION
This is mostly prep-work for upcoming features like BioEnrollments, where we would want to avoid having to enter the PIN for each fingerprint-sample, when enrolling a new fingerprint. Although the `webauthn_hid`-example can already skip one PIN-entry now, too.

I'm aware that `PinProvider` might not be the greatest name now for this trait, but I think it's the right place to add the caching, since it is very related to PINs.

Note: Needs rebase, once #56 lands.