### PR TITLE
Fix getRetries CTAP 2.0 / 2.1 behavior

### DIFF
--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -463,9 +463,20 @@ where
             return Err(Error::Platform(PlatformError::PinTooLong));
         }
 
+        let uv_proto = select_uv_proto(&get_info_response).await?;
+
         let current_pin = match get_info_response.options.as_ref().unwrap().get("clientPin") {
             // Obtaining the current PIN, if one is set
-            Some(true) => Some(obtain_pin(self, pin_provider, timeout).await?),
+            Some(true) => Some(
+                obtain_pin(
+                    self,
+                    &get_info_response,
+                    uv_proto.version(),
+                    pin_provider,
+                    timeout,
+                )
+                .await?,
+            ),
 
             // No PIN set yet
             Some(false) => None,
@@ -478,7 +489,6 @@ where
 
         // In preparation for obtaining pinUvAuthToken, the platform:
         // * Obtains a shared secret.
-        let uv_proto = select_uv_proto(&get_info_response).await?;
         let (public_key, shared_secret) = obtain_shared_secret(self, &uv_proto, timeout).await?;
 
         // paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)

--- a/libwebauthn/src/proto/ctap2/model/client_pin.rs
+++ b/libwebauthn/src/proto/ctap2/model/client_pin.rs
@@ -79,9 +79,9 @@ impl Ctap2ClientPinRequest {
         }
     }
 
-    pub fn new_get_pin_retries() -> Self {
+    pub fn new_get_pin_retries(pin_proto: Option<Ctap2PinUvAuthProtocol>) -> Self {
         Self {
-            protocol: None,
+            protocol: pin_proto,
             command: Ctap2PinUvAuthProtocolCommand::GetPinRetries,
             key_agreement: None,
             uv_auth_param: None,

--- a/libwebauthn/src/proto/ctap2/model/get_info.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_info.rs
@@ -65,41 +65,90 @@ pub struct Ctap2GetInfoResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub force_pin_change: Option<bool>,
 
+    /// minPINLength (0x0D)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_pin_length: Option<u32>,
 
+    /// firmwareVersion (0x0E)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub firmware_version: Option<u32>,
 
+    /// maxCredBlobLength (0x0F)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_cred_blob_length: Option<u32>,
 
+    /// maxRPIDsForSetMinPINLength (0x10)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_rpids_for_setminpinlength: Option<u32>,
 
+    /// preferredPlatformUvAttempts (0x11)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_platform_uv_attempts: Option<u32>,
 
+    /// uvModality (0x12)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uv_modality: Option<u32>,
 
+    /// certifications (0x13)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub certifications: Option<HashMap<String, u32>>,
 
+    /// remainingDiscoverableCredentials (0x14)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remaining_discoverable_creds: Option<u32>,
 
+    /// vendorPrototypeConfigCommands (0x15)
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vendor_proto_config_cmds: Option<Vec<u32>>,
+
+    /// attestationFormats (0x16)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attestation_formats: Option<Vec<String>>,
+
+    /// uvCountSinceLastPinEntry (0x17)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uv_count_since_last_pin_entry: Option<u32>,
+
+    /// longTouchForReset (0x18)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long_touch_for_reset: Option<bool>,
+
+    /// encIdentifier (0x19)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enc_identifier: Option<ByteBuf>,
+
+    /// transportsForReset (0x1A)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transports_for_reset: Option<Vec<String>>,
+
+    /// pinComplexityPolicy (0x1B)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin_complexity_policy: Option<bool>,
+
+    /// pinComplexityPolicyURL (0x1C)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin_complexity_policy_url: Option<ByteBuf>,
+
+    /// maxPINLength (0x1D)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_pin_length: Option<u32>,
 }
 
 impl Ctap2GetInfoResponse {


### PR DESCRIPTION
For some reason I have not tried my Nitrokey3 with this lib before and noticed some issues.

1. The GetInfo response contained already some 2.2 members, which made serde unhappy, so I added all of the 2.2 fields (although, we _should_ ignore all unknown keys, but serde_indexed doesn't seem to have this functionality)
2. `getRetries` requires the PIN protocol in CTAP 2.0, but not anymore in 2.1.
3. Sadly, my NK3 still error-ed out with MissingParameter, because it has a bug and reports full 2.1 support, but still requires the PIN protocol (see [here](https://github.com/Nitrokey/nitrokey-fido2-firmware/issues/77)). So I changed the hard error into a soft error, as the displaying of the retry counter is optional anyways.